### PR TITLE
Allow message to be left blank

### DIFF
--- a/app/javascript/controllers/konami_controller.js
+++ b/app/javascript/controllers/konami_controller.js
@@ -7,7 +7,7 @@ export default class extends Controller {
     this.konamiIndex = 0;
     this.handleKeydown = this.handleKeydown.bind(this);
     window.addEventListener('keydown', this.handleKeydown);
-    console.log("Konami controller connected");
+    // console.log("Konami controller connected");
   }
 
   disconnect() {
@@ -15,7 +15,7 @@ export default class extends Controller {
   }
 
   handleKeydown(event) {
-    console.log(event.keyCode);
+    // console.log(event.keyCode);
     if (event.keyCode === this.konamiCode[this.konamiIndex]) {
       this.konamiIndex++;
       if (this.konamiIndex === this.konamiCode.length) {

--- a/app/jobs/ticker_upload_job.rb
+++ b/app/jobs/ticker_upload_job.rb
@@ -4,7 +4,7 @@ class TickerUploadJob < ApplicationJob
   def perform(manipulation_id = nil)
     manipulation = Manipulation.find_by(id: manipulation_id)
     if manipulation
-      Arduino.new(insider_text: manipulation.message).update!
+      Arduino.new(insider_text: manipulation.message, manipulation: true).update!
     else
       Arduino.new.update!
     end

--- a/app/models/manipulation.rb
+++ b/app/models/manipulation.rb
@@ -16,7 +16,7 @@
 class Manipulation < ApplicationRecord
   validates :category, presence: true
   validates :newvalue, numericality: { greater_than: 0 }
-  validates :message, length: { maximum: 29 }, format: { with: /\A[[:ascii:]]\z/, message: "only allows ASCII characters" }
+  validates :message, length: { maximum: 29 }, format: { allow_blank: true, with: /\A[[:ascii:]]\z/, message: "only allows ASCII characters" }
   validates :action, inclusion: { in: [ "add", "subtract" ] }
   # validates :value_type, inclusion: { in: [ "literal", "percent" ] }
 

--- a/app/services/arduino.rb
+++ b/app/services/arduino.rb
@@ -1,11 +1,13 @@
 class Arduino
   def initialize(
+    manipulation: false,
     insider_text: nil,
     scroll_delay: 10,
     ticker_red: "10", # hexadecimal
     ticker_green: "00", # hexadecimal
     ticker_blue: "00" # hexadecimal
   )
+    @manipulation = manipulation
     @insider_text = insider_text.upcase.center(29)
     @scroll_delay = scroll_delay
     @ticker_red = ticker_red

--- a/vendor/arduino/ticker/ticker.cpp.erb
+++ b/vendor/arduino/ticker/ticker.cpp.erb
@@ -991,11 +991,25 @@ void showticker()
 void loop()
 {
 
-  <% if @insider_text %>
+  <% if @manipulation %>
+
     showcountdown();
     showstarfield();
-    showinsider();
+
+    <% if @insider_text %>
+      showinsider();
+    <% end %>
+
+    // loop this multiple times to make sure the manipulation methods don't repeat
+    // before another call is made to update
     showticker();
+    showticker();
+    showticker();
+    showticker();
+    showticker();
+    showticker();
+    // TODO: measure how long it takes a full ticker message to display
+
   <% else %>
     showticker();
   <% end %>


### PR DESCRIPTION
Validations were still failing when a valid amount was present, but the message was blank. 

Also cleans up the console and makes some improvements to the ticker when there isn't a message. 