### PR TITLE
Let's see what happens if I remove the query limit on prices

### DIFF
--- a/app/models/price.rb
+++ b/app/models/price.rb
@@ -20,7 +20,7 @@
 class Price < ApplicationRecord
   belongs_to :stock
 
-  default_scope { order(date: :desc).limit(100) }
+  default_scope { order(date: :desc) }
 
   scope :weekly, -> { where(date: 7.days.ago..) }
 


### PR DESCRIPTION
Maybe the flatter graphs are because of this?